### PR TITLE
switch from libusb 0.1 to libusb 1.0

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@ HOST_CC = $(HOST_COMPILE)$(CC)
 
 CPPFLAGS += -DVERSION=\"$(VERSION)\" -DBUILD_DATE="\"$(BUILD_DATE)\"" -D_GNU_SOURCE -D_POSIX_C_SOURCE=200809L
 CFLAGS += -W -Wall -O2 -pedantic -std=c99
-LIBS += -lusb
+LIBS += -lusb-1.0
 
 DEPENDS = Makefile ../config.mk
 

--- a/src/cold-flash.c
+++ b/src/cold-flash.c
@@ -21,7 +21,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <errno.h>
-#include <usb.h>
+#include <libusb-1.0/libusb.h>
 
 #include "global.h"
 
@@ -168,35 +168,35 @@ struct xloader_msg xloader_msg_create(uint32_t type, struct image * image) {
 
 }
 
-static int read_asic(usb_dev_handle * udev, uint8_t * asic_buffer, int size, int asic_size) {
+static int read_asic(libusb_device_handle * udev, uint8_t * asic_buffer, int size, int asic_size) {
 
-	int ret;
+	int ret, actual_length;
 
 	printf("Waiting for ASIC ID...\n");
-	ret = usb_bulk_read(udev, READ_DEV, (char *)asic_buffer, size, READ_TIMEOUT);
-	if ( ret != asic_size )
+	ret = libusb_bulk_transfer(udev, READ_DEV, (unsigned char *)asic_buffer, size, &actual_length, READ_TIMEOUT);
+	if ( ret < 0 || actual_length != asic_size )
 		ERROR_RETURN("Invalid size of ASIC ID", -1);
 
 	return 0;
 
 }
 
-static int send_2nd(usb_dev_handle * udev, struct image * image) {
+static int send_2nd(libusb_device_handle * udev, struct image * image) {
 
 	uint8_t buffer[1024];
 	uint32_t need, readed;
-	int ret;
+	int ret, actual_length;
 
 	printf("Sending OMAP peripheral boot message...\n");
-	ret = usb_bulk_write(udev, WRITE_DEV, (char *)&omap_peripheral_msg, sizeof(omap_peripheral_msg), WRITE_TIMEOUT);
+	ret = libusb_bulk_transfer(udev, WRITE_DEV, (unsigned char *)&omap_peripheral_msg, sizeof(omap_peripheral_msg), &actual_length, WRITE_TIMEOUT);
 	SLEEP(5000);
-	if ( ret != sizeof(omap_peripheral_msg) )
+	if ( ret < 0 || actual_length != sizeof(omap_peripheral_msg) )
 		ERROR_RETURN("Sending OMAP peripheral boot message failed", -1);
 
 	printf("Sending 2nd X-Loader image size...\n");
-	ret = usb_bulk_write(udev, WRITE_DEV, (char *)&image->size, 4, WRITE_TIMEOUT);
+	ret = libusb_bulk_transfer(udev, WRITE_DEV, (unsigned char *)&image->size, 4, &actual_length, WRITE_TIMEOUT);
 	SLEEP(5000);
-	if ( ret != 4 )
+	if ( ret < 0 || actual_length != 4 )
 		ERROR_RETURN("Sending 2nd X-Loader image size failed", -1);
 
 	printf("Sending 2nd X-Loader image...\n");
@@ -210,8 +210,10 @@ static int send_2nd(usb_dev_handle * udev, struct image * image) {
 		ret = image_read(image, buffer, need);
 		if ( ret == 0 )
 			break;
-		if ( usb_bulk_write(udev, WRITE_DEV, (char *)buffer, ret, WRITE_TIMEOUT) != ret )
+		if ( libusb_bulk_transfer(udev, WRITE_DEV, (unsigned char *)buffer, ret, &actual_length, WRITE_TIMEOUT) < 0 )
 			PRINTF_ERROR_RETURN("Sending 2nd X-Loader image failed", -1);
+		if ( ret != actual_length )
+			PRINTF_ERROR_RETURN("Sending 2nd X-Loader image failed (incomplete bulk transfer)", -1);
 		readed += ret;
 		printf_progressbar(readed, image->size);
 	}
@@ -221,24 +223,24 @@ static int send_2nd(usb_dev_handle * udev, struct image * image) {
 
 }
 
-static int send_secondary(usb_dev_handle * udev, struct image * image) {
+static int send_secondary(libusb_device_handle * udev, struct image * image) {
 
 	struct xloader_msg init_msg;
 	uint8_t buffer[1024];
 	uint32_t need, readed;
-	int ret;
+	int ret, actual_length;
 
 	init_msg = xloader_msg_create(XLOADER_MSG_TYPE_SEND, image);
 
 	printf("Sending X-Loader init message...\n");
-	ret = usb_bulk_write(udev, WRITE_DEV, (char *)&init_msg, sizeof(init_msg), WRITE_TIMEOUT);
+	ret = libusb_bulk_transfer(udev, WRITE_DEV, (unsigned char *)&init_msg, sizeof(init_msg), &actual_length, WRITE_TIMEOUT);
 	SLEEP(5000);
-	if ( ret != sizeof(init_msg) )
+	if ( ret < 0 || actual_length != sizeof(init_msg) )
 		ERROR_RETURN("Sending X-Loader init message failed", -1);
 
 	printf("Waiting for X-Loader response...\n");
-	ret = usb_bulk_read(udev, READ_DEV, (char *)&buffer, 4, READ_TIMEOUT); /* 4 bytes - dummy value */
-	if ( ret != 4 )
+	ret = libusb_bulk_transfer(udev, READ_DEV, (unsigned char *)&buffer, 4, &actual_length, READ_TIMEOUT); /* 4 bytes - dummy value */
+	if ( ret < 0 || actual_length != 4 )
 		ERROR_RETURN("No response", -1);
 
 	printf("Sending Secondary image...\n");
@@ -252,27 +254,30 @@ static int send_secondary(usb_dev_handle * udev, struct image * image) {
 		ret = image_read(image, buffer, need);
 		if ( ret == 0 )
 			break;
-		if ( usb_bulk_write(udev, WRITE_DEV, (char *)buffer, ret, WRITE_TIMEOUT) != ret )
+		if ( libusb_bulk_transfer(udev, WRITE_DEV, (unsigned char *)buffer, ret, &actual_length, WRITE_TIMEOUT) < 0 )
 			PRINTF_ERROR_RETURN("Sending Secondary image failed", -1);
+		if ( ret != actual_length)
+			PRINTF_ERROR_RETURN("Sending Secondary image failed (incomplete bulk transfer)", -1);
 		readed += ret;
 		printf_progressbar(readed, image->size);
 	}
 	SLEEP(5000);
 
 	printf("Waiting for X-Loader response...\n");
-	ret = usb_bulk_read(udev, READ_DEV, (char *)&buffer, 4, READ_TIMEOUT); /* 4 bytes - dummy value */
-	if ( ret != 4 )
+	ret = libusb_bulk_transfer(udev, READ_DEV, (unsigned char *)&buffer, 4, &actual_length, READ_TIMEOUT); /* 4 bytes - dummy value */
+	if ( ret < 0 || actual_length != 4 )
 		ERROR_RETURN("No response", -1);
 
 	return 0;
 
 }
 
-static int ping_timeout(usb_dev_handle * udev) {
+static int ping_timeout(libusb_device_handle * udev) {
 
 	int ret;
 	int pong = 0;
 	int try_ping = 10;
+	int actual_length;
 
 	while ( try_ping > 0 ) {
 
@@ -280,16 +285,16 @@ static int ping_timeout(usb_dev_handle * udev) {
 		int try_read = 4;
 
 		printf("Sending X-Loader ping message\n");
-		ret = usb_bulk_write(udev, WRITE_DEV, (char *)&ping_msg, sizeof(ping_msg), WRITE_TIMEOUT);
-		if ( ret != sizeof(ping_msg) )
+		ret = libusb_bulk_transfer(udev, WRITE_DEV, (unsigned char *)&ping_msg, sizeof(ping_msg), &actual_length, WRITE_TIMEOUT);
+		if ( ret < 0 || actual_length != sizeof(ping_msg) )
 			ERROR_RETURN("Sending X-Loader ping message failed", -1);
 
 		printf("Waiting for X-Loader pong response...\n");
 		while ( try_read > 0 ) {
 
 			uint32_t ping_read;
-			ret = usb_bulk_read(udev, READ_DEV, (char *)&ping_read, sizeof(ping_read), READ_TIMEOUT);
-			if ( ret == sizeof(ping_read) ) {
+			ret = libusb_bulk_transfer(udev, READ_DEV, (unsigned char *)&ping_read, sizeof(ping_read), &actual_length, READ_TIMEOUT);
+			if ( ret == 0 && actual_length == sizeof(ping_read) ) {
 				printf("Got it\n");
 				pong = 1;
 				break;
@@ -401,12 +406,12 @@ int cold_flash(struct usb_device_info * dev, struct image * x2nd, struct image *
 
 int leave_cold_flash(struct usb_device_info * dev) {
 
-	int ret;
+	int ret, actual_length;
 
 	printf("Sending OMAP memory boot message...\n");
-	ret = usb_bulk_write(dev->udev, WRITE_DEV, (char *)&omap_memory_msg, sizeof(omap_memory_msg), WRITE_TIMEOUT);
+	ret = libusb_bulk_transfer(dev->udev, WRITE_DEV, (unsigned char *)&omap_memory_msg, sizeof(omap_memory_msg), &actual_length, WRITE_TIMEOUT);
 	SLEEP(5000);
-	if ( ret != sizeof(omap_memory_msg) )
+	if ( ret < 0 || actual_length != sizeof(omap_memory_msg) )
 		ERROR_RETURN("Sending OMAP memory boot message failed", -1);
 
 	SLEEP(250000);

--- a/src/device.c
+++ b/src/device.c
@@ -31,6 +31,7 @@ static const char * devices[] = {
 	[DEVICE_RX_44] = "RX-44",
 	[DEVICE_RX_48] = "RX-48",
 	[DEVICE_RX_51] = "RX-51",
+	[DEVICE_RM_680] = "RM-680",
 };
 
 enum device device_from_string(const char * device) {
@@ -63,6 +64,7 @@ static const char * long_devices[] = {
 	[DEVICE_RX_44] = "Nokia N810",
 	[DEVICE_RX_48] = "Nokia N810 Wimax",
 	[DEVICE_RX_51] = "Nokia N900",
+	[DEVICE_RM_680] = "Nokia N950",
 };
 
 const char * device_to_long_string(enum device device) {

--- a/src/device.c
+++ b/src/device.c
@@ -32,6 +32,7 @@ static const char * devices[] = {
 	[DEVICE_RX_48] = "RX-48",
 	[DEVICE_RX_51] = "RX-51",
 	[DEVICE_RM_680] = "RM-680",
+	[DEVICE_RM_696] = "RM-696",
 };
 
 enum device device_from_string(const char * device) {
@@ -65,6 +66,7 @@ static const char * long_devices[] = {
 	[DEVICE_RX_48] = "Nokia N810 Wimax",
 	[DEVICE_RX_51] = "Nokia N900",
 	[DEVICE_RM_680] = "Nokia N950",
+	[DEVICE_RM_696] = "Nokia N9",
 };
 
 const char * device_to_long_string(enum device device) {

--- a/src/device.h
+++ b/src/device.h
@@ -31,6 +31,7 @@ enum device {
 	DEVICE_RX_48, /* Nokia N810 WiMax */
 	DEVICE_RX_51, /* Nokia N900 */
 	DEVICE_RM_680, /* Nokia N950 */
+	DEVICE_RM_696, /* Nokia N9 */
 	DEVICE_COUNT,
 };
 

--- a/src/device.h
+++ b/src/device.h
@@ -30,6 +30,7 @@ enum device {
 	DEVICE_RX_44, /* Nokia N810 */
 	DEVICE_RX_48, /* Nokia N810 WiMax */
 	DEVICE_RX_51, /* Nokia N900 */
+	DEVICE_RM_680, /* Nokia N950 */
 	DEVICE_COUNT,
 };
 

--- a/src/disk.c
+++ b/src/disk.c
@@ -277,13 +277,19 @@ int disk_init(struct usb_device_info * dev) {
 	unsigned int devnum;
 	unsigned int busnum;
 
-	struct usb_device * device;
+	uint8_t usbdevnum;
+	uint8_t usbbusnum;
 
-	device = usb_device(dev->udev);
-	if ( ! device || ! device->bus ) {
+	struct libusb_device * device;
+
+	device = libusb_get_device(dev->udev);
+	if ( ! device ) {
 		ERROR_INFO("Cannot read usb devnum and busnum");
 		return -1;
 	}
+
+	usbbusnum = libusb_get_bus_number(device);
+	usbdevnum = libusb_get_port_number(device);
 
 	dir = opendir("/sys/dev/block/");
 	if ( ! dir ) {
@@ -324,7 +330,7 @@ int disk_init(struct usb_device_info * dev) {
 
 		fclose(f);
 
-		if ( devnum != device->devnum || device->bus->location != busnum )
+		if ( devnum != usbdevnum || usbbusnum != busnum )
 			continue;
 
 		if ( sscanf(dirent->d_name, "%d:%d", &maj, &min) != 2 ) {

--- a/src/libusb-sniff.c
+++ b/src/libusb-sniff.c
@@ -28,6 +28,9 @@
 
 struct myusb_dev_handle_t;
 typedef struct myusb_dev_handle_t usb_dev_handle;
+typedef struct myusb_dev_handle_t libusb_device_handle;
+
+#define LIBUSB_ENDPOINT_IN 0x80
 
 static char to_ascii(char c) {
 
@@ -117,6 +120,56 @@ int usb_bulk_read(usb_dev_handle * dev, int ep, char * bytes, int size, int time
 
 }
 
+int libusb_bulk_transfer(libusb_device_handle *dev, unsigned char ep, unsigned char *bytes, int size, int *actual_length, unsigned int timeout) {
+
+	static int (*real_libusb_bulk_transfer)(libusb_device_handle *dev, unsigned char ep, unsigned char *bytes, int size, int *actual_length, unsigned int timeout) = NULL;
+	int ret;
+
+	if ( ! real_libusb_bulk_transfer )
+		real_libusb_bulk_transfer = dlsym(RTLD_NEXT, "libusb_bulk_transfer");
+
+	if (ep == LIBUSB_ENDPOINT_IN) {
+		/* bulk read */
+
+		ret = real_libusb_bulk_transfer(dev, ep, bytes, size, actual_length, timeout);
+
+		if ( ! getenv("USBSNIFF_SKIP_READ") ) {
+
+			printf("\n==== usb_bulk_read (ep=%d size=%d timeout=%d) ret = %d ====\n", ep, size, timeout, (ret < 0) ? ret : *actual_length);
+			if ( ret == 0 ) {
+				dump_bytes((char*) bytes, *actual_length);
+				printf("====\n");
+			}
+
+			if ( getenv("USBSNIFF_WAIT") ) {
+				printf("Press ENTER"); fflush(stdout); getchar();
+			}
+
+		}
+
+		return ret;
+
+	} else {
+		/* bulk write */
+
+		if ( ! getenv("USBSNIFF_SKIP_WRITE") ) {
+
+			printf("\n==== usb_bulk_write (ep=%d size=%d timeout=%d) ====\n", ep, size, timeout);
+			dump_bytes((char*) bytes, size);
+			printf("====\n");
+
+			if ( getenv("USBSNIFF_WAIT") ) {
+				printf("Press ENTER"); fflush(stdout); getchar();
+			}
+
+		}
+
+		return real_libusb_bulk_transfer(dev, ep, bytes, size, actual_length, timeout);
+
+	}
+
+}
+
 int usb_control_msg(usb_dev_handle *dev, int requesttype, int request, int value, int index, char *bytes, int size, int timeout) {
 
 	static int (*real_usb_control_msg)(usb_dev_handle *dev, int requesttype, int request, int value, int index, char *bytes, int size, int timeout) = NULL;
@@ -157,12 +210,65 @@ int usb_control_msg(usb_dev_handle *dev, int requesttype, int request, int value
 
 }
 
+int libusb_control_msg(libusb_device_handle *dev, int requesttype, int request, int value, int index, unsigned char *bytes, int size, int timeout) {
+
+	static int (*real_usb_control_msg)(usb_dev_handle *dev, int requesttype, int request, int value, int index, unsigned char *bytes, int size, int timeout) = NULL;
+	int ret;
+
+	if ( ! real_usb_control_msg )
+		real_usb_control_msg = dlsym(RTLD_NEXT, "libusb_control_msg");
+
+	if ( requesttype == 64 && ! getenv("USBSNIFF_SKIP_CONTROL") ) {
+
+		printf("\n==== usb_control_msg(requesttype=%d, request=%d, value=%d, index=%d, size=%d, timeout=%d) ====\n", requesttype, request, value, index, size, timeout);
+		dump_bytes((char*) bytes, size);
+		printf("====\n");
+
+		if ( getenv("USBSNIFF_WAIT") ) {
+			printf("Press ENTER"); fflush(stdout); getchar();
+		}
+
+	}
+
+	ret = real_usb_control_msg(dev, requesttype, request, value, index, bytes, size, timeout);
+
+	if ( requesttype != 64 && ! getenv("USBSNIFF_SKIP_CONTROL") ) {
+
+		printf("\n==== usb_control_msg(requesttype=%d, request=%d, value=%d, index=%d, size=%d, timeout=%d) ret = %d ====\n", requesttype, request, value, index, size, timeout, ret);
+		if ( ret > 0 ) {
+			dump_bytes((char*) bytes, ret);
+			printf("====\n");
+		}
+
+		if ( getenv("USBSNIFF_WAIT") ) {
+			printf("Press ENTER"); fflush(stdout); getchar();
+		}
+
+	}
+
+	return ret;
+
+}
+
 int usb_set_configuration(usb_dev_handle *dev, int configuration) {
 
 	static int (*real_usb_set_configuration)(usb_dev_handle *dev, int configuration) = NULL;
 
 	if ( ! real_usb_set_configuration )
 		real_usb_set_configuration = dlsym(RTLD_NEXT, "usb_set_configuration");
+
+	printf("\n==== usb_set_configuration (configuration=%d) ====\n", configuration);
+
+	return real_usb_set_configuration(dev, configuration);
+
+}
+
+int libusb_set_configuration(libusb_device_handle *dev, int configuration) {
+
+	static int (*real_usb_set_configuration)(usb_dev_handle *dev, int configuration) = NULL;
+
+	if ( ! real_usb_set_configuration )
+		real_usb_set_configuration = dlsym(RTLD_NEXT, "libusb_set_configuration");
 
 	printf("\n==== usb_set_configuration (configuration=%d) ====\n", configuration);
 
@@ -183,6 +289,19 @@ int usb_claim_interface(usb_dev_handle *dev, int interface) {
 
 }
 
+int libusb_claim_interface(libusb_device_handle *dev, int interface) {
+
+	static int (*real_usb_claim_interface)(usb_dev_handle *dev, int interface) = NULL;
+
+	if ( ! real_usb_claim_interface )
+		real_usb_claim_interface = dlsym(RTLD_NEXT, "libusb_claim_interface");
+
+	printf("\n==== usb_claim_interface (interface=%d) ====\n", interface);
+
+	return real_usb_claim_interface(dev, interface);
+
+}
+
 int usb_set_altinterface(usb_dev_handle *dev, int alternate) {
 
 	static int (*real_usb_set_altinterface)(usb_dev_handle *dev, int alternate) = NULL;
@@ -193,5 +312,18 @@ int usb_set_altinterface(usb_dev_handle *dev, int alternate) {
 	printf("\n==== usb_set_altinterface (alternate=%d) ====\n", alternate);
 
 	return real_usb_set_altinterface(dev, alternate);
+
+}
+
+int libusb_set_interface_alt_setting(libusb_device_handle *dev, int interface, int alternate) {
+
+	static int (*real_usb_set_altinterface)(usb_dev_handle *dev, int interface, int alternate) = NULL;
+
+	if ( ! real_usb_set_altinterface )
+		real_usb_set_altinterface = dlsym(RTLD_NEXT, "libusb_set_interface_alt_setting");
+
+	printf("\n==== usb_set_altinterface (alternate=%d) ====\n", alternate);
+
+	return real_usb_set_altinterface(dev, interface, alternate);
 
 }

--- a/src/libusb-sniff.c
+++ b/src/libusb-sniff.c
@@ -23,6 +23,7 @@
 
 #define _GNU_SOURCE
 #include <stdio.h>
+#include <stdlib.h>
 #include <dlfcn.h>
 #include <usb.h>
 

--- a/src/libusb-sniff.c
+++ b/src/libusb-sniff.c
@@ -25,7 +25,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <dlfcn.h>
-#include <usb.h>
+
+struct myusb_dev_handle_t;
+typedef struct myusb_dev_handle_t usb_dev_handle;
 
 static char to_ascii(char c) {
 

--- a/src/usb-device.c
+++ b/src/usb-device.c
@@ -25,11 +25,7 @@
 #include <ctype.h>
 #include <signal.h>
 
-#include <usb.h>
-
-#ifdef LIBUSB_HAS_DETACH_KERNEL_DRIVER_NP
-#include <sys/ioctl.h>
-#endif
+#include <libusb-1.0/libusb.h>
 
 #include "global.h"
 #include "device.h"
@@ -77,38 +73,31 @@ static void usb_flash_device_info_print(const struct usb_flash_device * dev) {
 
 }
 
-static void usb_reattach_kernel_driver(usb_dev_handle * udev, int interface) {
+static void usb_reattach_kernel_driver(libusb_device_handle * udev, int interface) {
 
-#ifdef LIBUSB_HAS_DETACH_KERNEL_DRIVER_NP
-	struct {
-		int ifno;
-		int ioctl_code;
-		void * data;
-	} command = {
-		.ifno = interface,
-		.ioctl_code = _IO('U', 23),
-		.data = NULL,
-	};
-
-	if ( interface < 0 )
-		return;
-
-	usb_release_interface(udev, interface);
-	ioctl(*((int *)udev), _IOWR('U', 18, command), &command);
-#endif
+	PRINTF_LINE("Reattach kernel driver to USB interface...");
+	PRINTF_END();
+	libusb_release_interface(udev, interface);
+	libusb_attach_kernel_driver(udev, interface);
 
 }
 
-static void usb_descriptor_info_print(usb_dev_handle * udev, struct usb_device * dev, char * product, size_t size) {
+static void usb_descriptor_info_print(libusb_device_handle * udev, struct libusb_device * dev, char * product, size_t size) {
 
+	struct libusb_device_descriptor desc;
 	char buf[1024];
 	char buf2[1024];
 	unsigned int x;
 	int ret;
 	int i;
 
+	if (libusb_get_device_descriptor(dev, &desc) < 0) {
+		PRINTF_LINE("libusb_get_device_descriptor() failed");
+		PRINTF_END();
+		return;
+	}
 	memset(buf, 0, sizeof(buf));
-	usb_get_string_simple(udev, dev->descriptor.iProduct, buf, sizeof(buf));
+	libusb_get_string_descriptor_ascii(udev, desc.iProduct, (unsigned char *) buf, sizeof(buf));
 	PRINTF_LINE("USB device product string: %s", buf[0] ? buf : "(not detected)");
 	PRINTF_END();
 
@@ -117,7 +106,7 @@ static void usb_descriptor_info_print(usb_dev_handle * udev, struct usb_device *
 
 	memset(buf, 0, sizeof(buf));
 	memset(buf2, 0, sizeof(buf2));
-	ret = usb_get_string_simple(udev, dev->descriptor.iSerialNumber, buf, sizeof(buf));
+	ret = libusb_get_string_descriptor_ascii(udev, desc.iSerialNumber, (unsigned char *) buf, sizeof(buf));
 	if ( ! isalnum(buf[0]) )
 		buf[0] = 0;
 	for ( i = 0; i < ret; i+=2 ) {
@@ -136,15 +125,22 @@ static void usb_descriptor_info_print(usb_dev_handle * udev, struct usb_device *
 
 }
 
-static struct usb_device_info * usb_device_is_valid(struct usb_device * dev) {
+static struct usb_device_info * usb_device_is_valid(struct libusb_device * dev) {
 
-	int i;
+	int err, i;
 	char product[1024];
 	struct usb_device_info * ret = NULL;
+	struct libusb_device_descriptor desc;
+
+	if (libusb_get_device_descriptor(dev, &desc) < 0) {
+		PRINTF_LINE("libusb_get_device_descriptor() failed");
+		PRINTF_END();
+		return NULL;
+	}
 
 	for ( i = 0; usb_devices[i].vendor; ++i ) {
 
-		if ( dev->descriptor.idVendor == usb_devices[i].vendor && dev->descriptor.idProduct == usb_devices[i].product ) {
+		if ( desc.idVendor == usb_devices[i].vendor && desc.idProduct == usb_devices[i].product ) {
 
 			printf("\b\b  ");
 			PRINTF_END();
@@ -153,9 +149,11 @@ static struct usb_device_info * usb_device_is_valid(struct usb_device * dev) {
 			PRINTF_END();
 
 			PRINTF_LINE("Opening USB...");
-			usb_dev_handle * udev = usb_open(dev);
-			if ( ! udev ) {
-				PRINTF_ERROR("usb_open failed");
+			libusb_device_handle * udev;
+
+			err = libusb_open(dev, &udev);
+			if ( err < 0 ) {
+				PRINTF_ERROR("libusb_open failed");
 				fprintf(stderr, "\n");
 				return NULL;
 			}
@@ -164,17 +162,15 @@ static struct usb_device_info * usb_device_is_valid(struct usb_device * dev) {
 
 			if ( usb_devices[i].interface >= 0 ) {
 
-#ifdef LIBUSB_HAS_DETACH_KERNEL_DRIVER_NP
 				PRINTF_LINE("Detaching kernel from USB interface...");
-				usb_detach_kernel_driver_np(udev, usb_devices[i].interface);
-#endif
+				libusb_detach_kernel_driver(udev, usb_devices[i].interface);
 
 				PRINTF_LINE("Claiming USB interface...");
-				if ( usb_claim_interface(udev, usb_devices[i].interface) < 0 ) {
-					PRINTF_ERROR("usb_claim_interface failed");
+				if ( libusb_claim_interface(udev, usb_devices[i].interface) < 0 ) {
+					PRINTF_ERROR("libusb_claim_interface failed");
 					fprintf(stderr, "\n");
 					usb_reattach_kernel_driver(udev, usb_devices[i].interface);
-					usb_close(udev);
+					libusb_close(udev);
 					return NULL;
 				}
 
@@ -182,22 +178,22 @@ static struct usb_device_info * usb_device_is_valid(struct usb_device * dev) {
 
 			if ( usb_devices[i].alternate >= 0 ) {
 				PRINTF_LINE("Setting alternate USB interface...");
-				if ( usb_set_altinterface(udev, usb_devices[i].alternate) < 0 ) {
-					PRINTF_ERROR("usb_claim_interface failed");
+				if ( libusb_set_interface_alt_setting(udev, usb_devices[i].interface, usb_devices[i].alternate) < 0 ) {
+					PRINTF_ERROR("libusb_claim_interface failed");
 					fprintf(stderr, "\n");
 					usb_reattach_kernel_driver(udev, usb_devices[i].interface);
-					usb_close(udev);
+					libusb_close(udev);
 					return NULL;
 				}
 			}
 
 			if ( usb_devices[i].configuration >= 0 ) {
 				PRINTF_LINE("Setting USB configuration...");
-				if ( usb_set_configuration(udev, usb_devices[i].configuration) < 0 ) {
-					PRINTF_ERROR("usb_set_configuration failed");
+				if ( libusb_set_configuration(udev, usb_devices[i].configuration) < 0 ) {
+					PRINTF_ERROR("libusb_set_configuration failed");
 					fprintf(stderr, "\n");
 					usb_reattach_kernel_driver(udev, usb_devices[i].interface);
-					usb_close(udev);
+					libusb_close(udev);
 					return NULL;
 				}
 			}
@@ -206,7 +202,7 @@ static struct usb_device_info * usb_device_is_valid(struct usb_device * dev) {
 			if ( ! ret ) {
 				ALLOC_ERROR();
 				usb_reattach_kernel_driver(udev, usb_devices[i].interface);
-				usb_close(udev);
+				libusb_close(udev);
 				return NULL;
 			}
 
@@ -232,7 +228,7 @@ static struct usb_device_info * usb_device_is_valid(struct usb_device * dev) {
 					ERROR("Device mishmash");
 					fprintf(stderr, "\n");
 					usb_reattach_kernel_driver(udev, usb_devices[i].interface);
-					usb_close(udev);
+					libusb_close(udev);
 					free(ret);
 					return NULL;
 				}
@@ -243,28 +239,6 @@ static struct usb_device_info * usb_device_is_valid(struct usb_device * dev) {
 			ret->udev = udev;
 			break;
 		}
-	}
-
-	return ret;
-
-}
-
-static struct usb_device_info * usb_search_device(struct usb_device * dev, int level) {
-
-	int i;
-	struct usb_device_info * ret = NULL;
-
-	if ( ! dev )
-		return NULL;
-
-	ret = usb_device_is_valid(dev);
-	if ( ret )
-		return ret;
-
-	for ( i = 0; i < dev->num_children; i++ ) {
-		ret = usb_search_device(dev->children[i], level + 1);
-		if ( ret )
-			break;
 	}
 
 	return ret;
@@ -282,14 +256,17 @@ static void signal_handler(int signum) {
 
 struct usb_device_info * usb_open_and_wait_for_device(void) {
 
-	struct usb_bus * bus;
+	libusb_device **devs;
+	libusb_device *dev;
 	struct usb_device_info * ret = NULL;
-	int i = 0;
 	void (*prev)(int);
 	static char progress[] = {'/','-','\\', '|'};
 
-	usb_init();
-	usb_find_busses();
+	if(libusb_init(NULL) < 0) {
+		PRINTF_LINE("libusb_init failed!");
+		PRINTF_END();
+		return NULL;
+	}
 
 	PRINTF_BACK();
 	printf("\n");
@@ -299,27 +276,17 @@ struct usb_device_info * usb_open_and_wait_for_device(void) {
 	prev = signal(SIGINT, signal_handler);
 
 	while ( ! signal_quit ) {
+		int i = 0;
 
-		PRINTF_LINE("Waiting for USB device... %c", progress[++i%sizeof(progress)]);
+		if (libusb_get_device_list(NULL, &devs) < 0) {
+			break;
+		}
 
-		usb_find_devices();
-
-		for ( bus = usb_get_busses(); bus; bus = bus->next ) {
-
-			if ( bus->root_dev )
-				ret = usb_search_device(bus->root_dev, 0);
-			else {
-				struct usb_device *dev;
-				for ( dev = bus->devices; dev; dev = dev->next ) {
-					ret = usb_search_device(dev, 0);
-					if ( ret )
-						break;
-				}
-			}
-
+		while ((dev = devs[i++]) != NULL) {
+			PRINTF_LINE("Waiting for USB device... %c", progress[++i%sizeof(progress)]);
+			ret = usb_device_is_valid(dev);
 			if ( ret )
 				break;
-
 		}
 
 		if ( ret )
@@ -345,7 +312,7 @@ struct usb_device_info * usb_open_and_wait_for_device(void) {
 void usb_close_device(struct usb_device_info * dev) {
 
 	usb_reattach_kernel_driver(dev->udev, dev->flash_device->interface);
-	usb_close(dev->udev);
+	libusb_close(dev->udev);
 	free(dev);
 
 }

--- a/src/usb-device.h
+++ b/src/usb-device.h
@@ -20,7 +20,7 @@
 #ifndef USB_DEVICE_H
 #define USB_DEVICE_H
 
-#include <usb.h>
+#include <libusb-1.0/libusb.h>
 
 #include "device.h"
 
@@ -47,7 +47,7 @@ struct usb_device_info {
 	enum device device;
 	int16_t hwrev;
 	const struct usb_flash_device * flash_device;
-	usb_dev_handle * udev;
+	libusb_device_handle * udev;
 	int data;
 };
 


### PR DESCRIPTION
No development happened on libusb0.1 for a couple of years. The newer libusb1.0 on the other hand is actively maintained. While there exists a wrapper library (providing the libusb0.1 API using libusb1.0), it's also unmaintained. Debian plans to remove libusb0.1 in the next release [0]. Since
there is not much point in providing libusb0.1 support in 0xFFFF (libusb1.0 exists since 2008), after this patch libusb1.0 is required.

[0] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=810470
