### PR TITLE
libusb 1.0 conversion fix and n950 identification support

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -31,6 +31,7 @@ static const char * devices[] = {
 	[DEVICE_RX_44] = "RX-44",
 	[DEVICE_RX_48] = "RX-48",
 	[DEVICE_RX_51] = "RX-51",
+	[DEVICE_RM_680] = "RM-680",
 };
 
 enum device device_from_string(const char * device) {
@@ -63,6 +64,7 @@ static const char * long_devices[] = {
 	[DEVICE_RX_44] = "Nokia N810",
 	[DEVICE_RX_48] = "Nokia N810 Wimax",
 	[DEVICE_RX_51] = "Nokia N900",
+	[DEVICE_RM_680] = "Nokia N950",
 };
 
 const char * device_to_long_string(enum device device) {

--- a/src/device.h
+++ b/src/device.h
@@ -30,6 +30,7 @@ enum device {
 	DEVICE_RX_44, /* Nokia N810 */
 	DEVICE_RX_48, /* Nokia N810 WiMax */
 	DEVICE_RX_51, /* Nokia N900 */
+	DEVICE_RM_680, /* Nokia N950 */
 	DEVICE_COUNT,
 };
 

--- a/src/usb-device.c
+++ b/src/usb-device.c
@@ -36,10 +36,10 @@
 #include "mkii.h"
 
 static struct usb_flash_device usb_devices[] = {
-	{ 0x0421, 0x0105,  2,  1, -1, FLASH_NOLO, { DEVICE_SU_18, DEVICE_RX_44, DEVICE_RX_48, DEVICE_RX_51, 0 } },
-	{ 0x0421, 0x0106,  0, -1, -1, FLASH_COLD, { DEVICE_RX_51, 0 } },
+	{ 0x0421, 0x0105,  2,  1, -1, FLASH_NOLO, { DEVICE_SU_18, DEVICE_RX_44, DEVICE_RX_48, DEVICE_RX_51, DEVICE_RM_680, 0 } },
+	{ 0x0421, 0x0106,  0, -1, -1, FLASH_COLD, { DEVICE_RX_51, DEVICE_RM_680, 0 } },
 	{ 0x0421, 0x01c7,  -1, -1, -1, FLASH_DISK, { DEVICE_RX_51, 0 } },
-	{ 0x0421, 0x01c8,  1,  1, -1, FLASH_MKII, { DEVICE_RX_51, 0 } },
+	{ 0x0421, 0x01c8,  1,  1, -1, FLASH_MKII, { DEVICE_RX_51, DEVICE_RM_680, 0 } },
 	{ 0x0421, 0x0431,  -1, -1, -1, FLASH_DISK, { DEVICE_SU_18, DEVICE_RX_34, 0 } },
 	{ 0x0421, 0x3f00,  2,  1, -1, FLASH_NOLO, { DEVICE_RX_34, 0 } },
 };
@@ -208,6 +208,8 @@ static struct usb_device_info * usb_device_is_valid(struct libusb_device * dev) 
 
 			if ( strstr(product, "N900") )
 				ret->device = DEVICE_RX_51;
+			else if ( strstr(product, "N950") )
+				ret->device = DEVICE_RM_680;
 			else
 				ret->device = DEVICE_UNKNOWN;
 

--- a/src/usb-device.h
+++ b/src/usb-device.h
@@ -50,6 +50,7 @@ struct usb_flash_device {
 struct usb_device_info {
 	enum device device;
 	int16_t hwrev;
+	int protocol_version;
 	const struct usb_flash_device * flash_device;
 	libusb_device_handle * udev;
 	int data;


### PR DESCRIPTION
Hi Pali,

Here are two small patches. One adds support for "0xFFFF -I" together with N950. Without this patch one could already flash the kernel via USB (I did not try anything else) but one could not identify the device using "-I". The other fixes a copy/paste mistake in my libusb1.0 patch, which has been found by Aaro.

-- Sebastian
